### PR TITLE
fix: Add tzdata package to docker image to allow setting timezones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN go build .
 
 FROM alpine
 
-RUN apk --no-cache add ca-certificates gcompat
+RUN apk --no-cache add ca-certificates gcompat tzdata
 
 WORKDIR /usr/local/bin
 


### PR DESCRIPTION
close #4 

- Add `tzdata` package to docker image to allow setting different timezones